### PR TITLE
Fixed windows install pulumi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,11 @@
         "pako": "~0.2.0"
       }
     },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -94,6 +99,11 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "currify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/currify/-/currify-4.0.0.tgz",
+      "integrity": "sha512-ABfH28PWp5oqqp31cLXJQdeMqoFNej9rJOu84wKhN3jPCH7FAZg3zY1MVI27PTFoqfPlxOyhGmh9PzOVv+yN2g=="
+    },
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
@@ -129,6 +139,14 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "requires": {
+        "pend": "~1.2.0"
       }
     },
     "findit2": {
@@ -315,6 +333,34 @@
         "wrappy": "1"
       }
     },
+    "onezip": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/onezip/-/onezip-4.2.3.tgz",
+      "integrity": "sha512-Ani0S5dtMmpp/kqYpMQh9vG2icbZMHcmVuVb3T0ryBc6GyJ4LxKbiJpJwC7gnzmlJuuqHnb8ekwA6V088YBDcA==",
+      "requires": {
+        "currify": "^4.0.0",
+        "findit2": "^2.2.3",
+        "glob": "^7.0.0",
+        "mkdirp": "^1.0.3",
+        "pipe-io": "^4.0.0",
+        "try-to-catch": "^3.0.0",
+        "yargs-parser": "^20.2.4",
+        "yauzl": "^2.6.0",
+        "yazl": "^2.4.1"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+        },
+        "try-to-catch": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/try-to-catch/-/try-to-catch-3.0.0.tgz",
+          "integrity": "sha512-eIm6ZXwR35jVF8By/HdbbkcaCDTBI5PpCPkejRKrYp0jyf/DbCCcRhHD7/O9jtFI3ewsqo9WctFEiJTS6i+CQA=="
+        }
+      }
+    },
     "pako": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
@@ -334,6 +380,11 @@
         "duplexify": "^3.5.0",
         "through2": "^2.0.3"
       }
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
     },
     "pipe-io": {
       "version": "4.0.0",
@@ -538,6 +589,28 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    },
+    "yargs-parser": {
+      "version": "20.2.7",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+      "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw=="
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "yazl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "requires": {
+        "buffer-crc32": "~0.2.3"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "jaguar": "^6.0.0",
     "node-fetch": "^2.6.0",
+    "onezip": "^4.2.3",
     "progress": "^2.0.0"
   },
   "devDependencies": {

--- a/src/install-pulumi/get-platform-url.js
+++ b/src/install-pulumi/get-platform-url.js
@@ -4,7 +4,7 @@ const getLatestPulumiVersion = require('../pulumi-version');
 const PULUMI_ZIP_URIS = {
   DARWIN: 'darwin-x64.tar.gz',
   LINUX: 'linux-x64.tar.gz',
-  WINDOWS: 'windows-x64.tar.gz'
+  WINDOWS: 'windows-x64.zip'
 };
 
 /**

--- a/src/install-pulumi/install-pulumi.js
+++ b/src/install-pulumi/install-pulumi.js
@@ -9,9 +9,20 @@ const getPlatformUrl = require('./get-platform-url');
 
 /// File constants
 const TOOLS_DIR = resolve(__dirname, '..', '..', 'tools');
-const TAR_FILE = join(TOOLS_DIR, 'pulumi.tar.gz');
-const EXEC_NAME = process.platform === 'win32' ? 'pulumi.exe' : 'pulumi';
-const EXEC_DIR = join(TOOLS_DIR, EXEC_NAME);
+const ZIPPED_FILE = join(
+  TOOLS_DIR,
+  process.platform === 'win32' || process.platform === 'win64'
+    ? 'pulumi.zip'
+    : 'pulumi.tar.gz'
+);
+const EXEC_NAME =
+  process.platform === 'win32' || process.platform === 'win64'
+    ? 'pulumi.exe'
+    : 'pulumi';
+const EXEC_DIR =
+  process.platform === 'win32' || process.platform === 'win64'
+    ? join(TOOLS_DIR, 'Pulumi', 'bin', EXEC_NAME)
+    : join(TOOLS_DIR, EXEC_NAME);
 
 /// Primary logic...
 try {
@@ -33,20 +44,20 @@ async function getZipUrl() {
   return getPlatformUrl(process.platform, process.arch);
 }
 // prettier-ignore
-async function downloadZip(url) { return await download(url, TAR_FILE); }
+async function downloadZip(url) { return await download(url, ZIPPED_FILE); }
 // prettier-ignore
-async function unzipDownload() { return await unzip(TAR_FILE, TOOLS_DIR); }
+async function unzipDownload() { return await unzip(ZIPPED_FILE, TOOLS_DIR); }
 // prettier-ignore
 async function setBinPerms() { return await setPerms(EXEC_DIR, 0o755) }
 async function purgeZip() {
   console.log('Cleaning up temporary artifacts...');
-  await purge(TAR_FILE);
+  await purge(ZIPPED_FILE);
   console.log('Removed temporary artifacts.');
   return Promise.resolve();
 }
 function notifyCompletion() {
   const msg =
-    process.platform === 'win32'
+    process.platform === 'win32' || process.platform === 'win64'
       ? 'Installation completed!'
       : 'Installation completed! 🎉';
   console.log('\x1b[1;35m%s\x1b[0m', msg);

--- a/src/install-pulumi/unzip.js
+++ b/src/install-pulumi/unzip.js
@@ -1,4 +1,5 @@
 const jaguar = require('jaguar');
+const onezip = require('onezip');
 const Progress = require('progress');
 
 /**
@@ -11,7 +12,10 @@ async function unzip(zipDir, destDir) {
     console.log(`Unpacking archive at ${zipDir}...`);
     console.log(zipDir, destDir);
     const prgbar = new Progress('[:bar] :percent ', { total: 100 });
-    const extract = jaguar.extract(zipDir, destDir);
+    const extract =
+      process.platform === 'win32' || process.platform === 'win64'
+        ? onezip.extract(zipDir, destDir)
+        : jaguar.extract(zipDir, destDir);
 
     extract.on('progress', percent => {
       prgbar.tick(percent);

--- a/src/pulumi-wrapper.js
+++ b/src/pulumi-wrapper.js
@@ -4,8 +4,14 @@
 const { spawn } = require('child_process');
 const { resolve } = require('path');
 
-const execName = process.platform === 'win32' || process.platform === 'win64' ? 'pulumi.exe' : './pulumi';
-const binPath = resolve(__dirname, '..', 'tools', 'pulumi');
+const execName =
+  process.platform === 'win32' || process.platform === 'win64'
+    ? 'pulumi.exe'
+    : './pulumi';
+const binPath =
+  process.platform === 'win32' || process.platform === 'win64'
+    ? resolve(__dirname, 'tools', 'Pulumi', 'bin')
+    : resolve(__dirname, 'tools', 'pulumi');
 const command = resolve(binPath, execName);
 spawn(command, process.argv.slice(2), {
   cwd: process.cwd(),


### PR DESCRIPTION
Pointed windows file at .zip instead since that's what pulumi offers for windows,
renamed TAR_FILE to ZIPPED_FILE,
updated EXEC_DIR to also include Pulumi/bin, because that's what's coming out of the zip,
updated binPath to also include Pulumi/bin, because that's what's coming out of the zip,
added onezip as dependency to handle unzipping of .zip files, when its' process.environment is windows-specific.